### PR TITLE
error: +32 spec/features/artists_spec.rb

### DIFF
--- a/spec/features/artists_spec.rb
+++ b/spec/features/artists_spec.rb
@@ -29,6 +29,6 @@ describe "artists", type:  :feature do
 
   it "shows the song count for each artist" do
     visit artists_path
-    expect(page).to have_content("2 song")
+    expect(page).to have_content("2 songs")
   end
 end


### PR DESCRIPTION
There is an error in the specs in line 32 of spec/features/artists_spec.rb.
Instead of expecting `2 songs`, the singular `2 song` is expected.

 ``` 
  it "shows the song count for each artist" do
    visit artists_path
    expect(page).to have_content("2 song")
  end
```